### PR TITLE
Reproducible shuffling of training data (fix portability issue #85 for macOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,7 @@ $(ALL_BOXES): $(patsubst %.tif,%.box,$(shell find $(GROUND_TRUTH_DIR) -name '*.t
 $(ALL_LSTMF): $(patsubst %.tif,%.lstmf,$(shell find $(GROUND_TRUTH_DIR) -name '*.tif'))
 	mkdir -p $(OUTPUT_DIR)
 	# https://www.gnu.org/software/coreutils/manual/html_node/Random-sources.html#Random-sources
-	find $(GROUND_TRUTH_DIR) -name '*.lstmf' | sort | \
-	  sort -R --random-source=<(openssl enc -aes-256-ctr -pass pass:"$(RANDOM_SEED)" -nosalt </dev/zero 2>/dev/null) > "$@"
+	find $(GROUND_TRUTH_DIR) -name '*.lstmf' | python3 shuffle.py $(RANDOM_SEED) > "$@"
 
 %.lstmf: %.box
 	tesseract $*.tif $* --psm $(PSM) lstm.train

--- a/shuffle.py
+++ b/shuffle.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# shuffle.py - shuffle the lines from stdin in pseudo random order
+#
+# Usage:
+#       shuffle.py [SEED]
+#
+# Sort and shuffle the lines read from stdin in pseudo random order
+# and write them to stdout.
+#
+# The optional SEED argument is used as a seed for the random generator.
+# A shuffled list can be reproduced by using the same seed again.
+
+import random
+import sys
+
+# If at least one argument was given, the first argument is used as the seed.
+if len(sys.argv) > 1:
+    random.seed(sys.argv[1])
+
+# Read lines from standard input.
+lines = sys.stdin.readlines()
+
+# First sort the input lines (directory entries may come in undefined order).
+lines.sort()
+
+# Then shuffle the lines.
+random.shuffle(lines)
+
+# Write the shuffled lines to standard output.
+sys.stdout.writelines(lines)


### PR DESCRIPTION
sort -R depends on OpenSSL and does not work on macOS because of missing named pipes,
so replace it with a well defined pseudo random shuffling Python script.

Signed-off-by: Stefan Weil <sw@weilnetz.de>