### PR TITLE
Added TESSDATA to README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ help:
 	@echo "    LEPTONICA_VERSION  Leptonica version. Default: $(LEPTONICA_VERSION)"
 	@echo "    TESSERACT_VERSION  Tesseract commit. Default: $(TESSERACT_VERSION)"
 	@echo "    TESSDATA_REPO      Tesseract model repo to use. Default: $(TESSDATA_REPO)"
+	@echo "    TESSDATA      	  Path to the .traineddata directory to start finetuning from. Default: $(LOCAL)/share/tessdata
 	@echo "    GROUND_TRUTH_DIR   Ground truth directory. Default: $(GROUND_TRUTH_DIR)"
 	@echo "    OUTPUT_DIR         Output directory for generated files. Default: $(OUTPUT_DIR)"
 	@echo "    MAX_ITERATIONS     Max iterations. Default: $(MAX_ITERATIONS)"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ LC_ALL := C
 SHELL := /bin/bash
 LOCAL := $(PWD)/usr
 PATH := $(LOCAL)/bin:$(PATH)
+
+# Path to the .traineddata directory to start finetuning from. Default: $(LOCAL)/share/tessdata
 TESSDATA =  $(LOCAL)/share/tessdata
 
 # Name of the model to be built. Default: $(MODEL_NAME)
@@ -79,7 +81,7 @@ help:
 	@echo "    LEPTONICA_VERSION  Leptonica version. Default: $(LEPTONICA_VERSION)"
 	@echo "    TESSERACT_VERSION  Tesseract commit. Default: $(TESSERACT_VERSION)"
 	@echo "    TESSDATA_REPO      Tesseract model repo to use. Default: $(TESSDATA_REPO)"
-	@echo "    TESSDATA      	  Path to the .traineddata directory to start finetuning from. Default: $(LOCAL)/share/tessdata
+	@echo "    TESSDATA           Path to the .traineddata directory to start finetuning from. Default: $(LOCAL)/share/tessdata
 	@echo "    GROUND_TRUTH_DIR   Ground truth directory. Default: $(GROUND_TRUTH_DIR)"
 	@echo "    OUTPUT_DIR         Output directory for generated files. Default: $(OUTPUT_DIR)"
 	@echo "    MAX_ITERATIONS     Max iterations. Default: $(MAX_ITERATIONS)"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Run `make help` to see all the possible targets and variables:
     LEPTONICA_VERSION  Leptonica version. Default: 1.78.0
     TESSERACT_VERSION  Tesseract commit. Default: 4.1.0
     TESSDATA_REPO      Tesseract model repo to use. Default: _best
-    TESSDATA           Path to the .traineddata directory to start finetuning from. Default: './usr/share/tessdata'
+    TESSDATA           Path to the .traineddata directory to start finetuning from. Default: ./usr/share/tessdata
     GROUND_TRUTH_DIR   Ground truth directory. Default: data/ground-truth
     OUTPUT_DIR         Output directory for generated files. Default: data/MODEL_NAME
     MAX_ITERATIONS     Max iterations. Default: 10000

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Run `make help` to see all the possible targets and variables:
     LEPTONICA_VERSION  Leptonica version. Default: 1.78.0
     TESSERACT_VERSION  Tesseract commit. Default: 4.1.0
     TESSDATA_REPO      Tesseract model repo to use. Default: _best
+    TESSDATA           Name of the tessadata file to start finetuning from (without file extension)
     GROUND_TRUTH_DIR   Ground truth directory. Default: data/ground-truth
     OUTPUT_DIR         Output directory for generated files. Default: data/MODEL_NAME
     MAX_ITERATIONS     Max iterations. Default: 10000

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Run `make help` to see all the possible targets and variables:
     LEPTONICA_VERSION  Leptonica version. Default: 1.78.0
     TESSERACT_VERSION  Tesseract commit. Default: 4.1.0
     TESSDATA_REPO      Tesseract model repo to use. Default: _best
-    TESSDATA           Name of the traineddata file to start finetuning from (without file extension)
+    TESSDATA           Path to the .traineddata directory to start finetuning from. Default: './usr/share/tessdata'
     GROUND_TRUTH_DIR   Ground truth directory. Default: data/ground-truth
     OUTPUT_DIR         Output directory for generated files. Default: data/MODEL_NAME
     MAX_ITERATIONS     Max iterations. Default: 10000

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Run `make help` to see all the possible targets and variables:
     LEPTONICA_VERSION  Leptonica version. Default: 1.78.0
     TESSERACT_VERSION  Tesseract commit. Default: 4.1.0
     TESSDATA_REPO      Tesseract model repo to use. Default: _best
-    TESSDATA           Name of the tessadata file to start finetuning from (without file extension)
+    TESSDATA           Name of the traineddata file to start finetuning from (without file extension)
     GROUND_TRUTH_DIR   Ground truth directory. Default: data/ground-truth
     OUTPUT_DIR         Output directory for generated files. Default: data/MODEL_NAME
     MAX_ITERATIONS     Max iterations. Default: 10000


### PR DESCRIPTION
Added the TESSDATA parameter description to README.md

As per the example at https://github.com/tesseract-ocr/tesstrain/wiki/GT4HistOCR#finetuning-based-on-scriptfraktur
