### PR TITLE
Drop "BUILD_TYPE" and remove default ground truth directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PUNC_FILE := $(OUTPUT_DIR)/$(MODEL_NAME).punc
 # Name of the model to continue from. Default: '$(START_MODEL)'
 START_MODEL =
 
-LAST_CHECKPOINT = $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)$(BUILD_TYPE)_checkpoint
+LAST_CHECKPOINT = $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)_checkpoint
 
 # Name of the proto model. Default: '$(PROTO_MODEL)'
 PROTO_MODEL = $(OUTPUT_DIR)/$(MODEL_NAME).traineddata
@@ -157,21 +157,19 @@ $(OUTPUT_DIR)/list.train: $(ALL_LSTMF)
 	  tail -n "$$eval" $(ALL_LSTMF) > "$(OUTPUT_DIR)/list.eval"
 
 ifdef START_MODEL
-BUILD_TYPE=Plus
 $(OUTPUT_DIR)/unicharset: $(ALL_GT)
 	@mkdir -p data/$(START_MODEL)
 	combine_tessdata -u $(TESSDATA)/$(START_MODEL).traineddata  data/$(START_MODEL)/$(MODEL_NAME)
 	unicharset_extractor --output_unicharset "$(OUTPUT_DIR)/my.unicharset" --norm_mode $(NORM_MODE) "$(ALL_GT)"
 	merge_unicharsets data/$(START_MODEL)/$(MODEL_NAME).lstm-unicharset $(OUTPUT_DIR)/my.unicharset  "$@"
 else
-BUILD_TYPE=
 $(OUTPUT_DIR)/unicharset: $(ALL_GT)
 	@mkdir -p $(OUTPUT_DIR)
 	unicharset_extractor --output_unicharset "$@" --norm_mode $(NORM_MODE) "$(ALL_GT)"
 endif
 
 # Start training
-training: $(OUTPUT_DIR)$(BUILD_TYPE).traineddata
+training: $(OUTPUT_DIR).traineddata
 
 $(ALL_GT): $(patsubst %.tif,%.gt.txt,$(shell find $(GROUND_TRUTH_DIR) -name '*.tif'))
 	@mkdir -p $(OUTPUT_DIR)
@@ -233,11 +231,11 @@ $(LAST_CHECKPOINT): unicharset lists $(PROTO_MODEL)
 	  --traineddata $(PROTO_MODEL) \
 	  --old_traineddata $(TESSDATA)/$(START_MODEL).traineddata \
 	  --continue_from data/$(START_MODEL)/$(MODEL_NAME).lstm \
-	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)$(BUILD_TYPE) \
+	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME) \
 	  --train_listfile $(OUTPUT_DIR)/list.train \
 	  --eval_listfile $(OUTPUT_DIR)/list.eval \
 	  --max_iterations $(MAX_ITERATIONS)
-$(OUTPUT_DIR)$(BUILD_TYPE).traineddata: $(LAST_CHECKPOINT)
+$(OUTPUT_DIR).traineddata: $(LAST_CHECKPOINT)
 	lstmtraining \
 	--stop_training \
 	--continue_from $(LAST_CHECKPOINT) \
@@ -250,12 +248,12 @@ $(LAST_CHECKPOINT): unicharset lists $(PROTO_MODEL)
 	  --debug_interval $(DEBUG_INTERVAL) \
 	  --traineddata $(PROTO_MODEL) \
 	  --net_spec "$(subst c###,c`head -n1 $(OUTPUT_DIR)/unicharset`,$(NET_SPEC))" \
-	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)$(BUILD_TYPE) \
+	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME) \
 	  --learning_rate 20e-4 \
 	  --train_listfile $(OUTPUT_DIR)/list.train \
 	  --eval_listfile $(OUTPUT_DIR)/list.eval \
 	  --max_iterations $(MAX_ITERATIONS)
-$(OUTPUT_DIR)$(BUILD_TYPE).traineddata: $(LAST_CHECKPOINT)
+$(OUTPUT_DIR).traineddata: $(LAST_CHECKPOINT)
 	lstmtraining \
 	--stop_training \
 	--continue_from $(LAST_CHECKPOINT) \

--- a/README.md
+++ b/README.md
@@ -36,10 +36,21 @@ Tesseract expects some configuration data (a file `fadical-stroke.txt`). To fetc
 
 -->
 
+## Choose model name
+
+Choose a name for your model. By convention, Tesseract stack models including
+language-specific resources use (lowercase) three-letter codes defined in
+[ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) with additional
+information separated by underscore. E.g., `chi_tra_vert` for **tra**ditional
+Chinese with **vert**ical typesetting. Language-independent (i.e. script-specific)
+models use the capitalized name of the script type as identifier. E.g.,
+`Hangul_vert` for Hangul script with vertical typesetting. In the following,
+the model name is referenced by `MODEL_NAME`.
+
 ## Provide ground truth
 
 Place ground truth consisting of line images and transcriptions in the folder
-`data/ground-truth`. This list of files will be split into training and
+`data/MODEL_NAME-ground-truth`. This list of files will be split into training and
 evaluation data, the ratio is defined by the `RATIO_TRAIN` variable.
 
 Images must be TIFF and have the extension `.tif`.
@@ -48,7 +59,7 @@ Transcriptions must be single-line plain text and have the same name as the
 line image but with `.tif` replaced by `.gt.txt`.
 
 The repository contains a ZIP archive with sample ground truth, see
-[ocrd-testset.zip](./ocrd-testset.zip). Extract it to `./data/ground-truth` and run
+[ocrd-testset.zip](./ocrd-testset.zip). Extract it to `./data/foo-ground-truth` and run
 `make training`.
 
 **NOTE:** If you want to generate line images for transcription from a full


### PR DESCRIPTION
Meanwhile, GT has to be placed in `data/MODEL_NAME-ground_truth`.
This commit fixes the documentation. In addition, the variable
`BUILD_TYPE` is removed to make sure thate the resulting models
are named as requested by the user.

Fixes #134 and #133