### PR TITLE
Add an option for reversed word boxes

### DIFF
--- a/generate_wordstr_box.py
+++ b/generate_wordstr_box.py
@@ -16,6 +16,9 @@ arg_parser.add_argument('-t', '--txt', nargs='?', metavar='TXT', help='Line text
 # Image file
 arg_parser.add_argument('-i', '--image', nargs='?', metavar='IMAGE', help='Image file', required=True)
 
+# Reading direction
+arg_parser.add_argument('-r', '--rtl', action='store_true', default=False, help='RTL input')
+
 args = arg_parser.parse_args()
 
 #
@@ -44,6 +47,8 @@ with io.open(args.txt, "r", encoding='utf-8') as f:
 # create WordStr line boxes for Indic & RTL
 for line in lines:
     line = unicodedata.normalize('NFC', line.strip())
+    if args.rtl:
+        line = line[::-1]
     if line:
         print("WordStr 0 0 %d %d 0 #%s" % (width, height, line))
         print("\t 0 0 %d %d 0" % (width, height))

--- a/generate_wordstr_box.py
+++ b/generate_wordstr_box.py
@@ -3,6 +3,7 @@
 import argparse
 import io
 import unicodedata
+import bidi.algorithm
 from PIL import Image, ImageChops, ImageOps
 
 #
@@ -48,7 +49,9 @@ with io.open(args.txt, "r", encoding='utf-8') as f:
 for line in lines:
     line = unicodedata.normalize('NFC', line.strip())
     if args.rtl:
-        line = line[::-1]
+        # FIXME: This should not be necessary. Compare with e.g. kraken
+        line = line.translate(str.maketrans("()[]{}»«><", ")(][}{«»<>"))
+        line = bidi.algorithm.get_display(line)
     if line:
         print("WordStr 0 0 %d %d 0 #%s" % (width, height, line))
         print("\t 0 0 %d %d 0" % (width, height))


### PR DESCRIPTION
Via `--rtl`, the string is simply reversed and the resulting box
file is equal to the one generated with
https://github.com/tesseract-ocr/tesstrain/pull/127.