### PR TITLE
[app][feat] enable target_error_rate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ RANDOM_SEED := 0
 # Ratio of train / eval training data. Default: $(RATIO_TRAIN)
 RATIO_TRAIN := 0.90
 
+# Default Target Error Rate
+TARGET_ERROR_RATE := 0.01
+
 # BEGIN-EVAL makefile-parser --make-help Makefile
 
 help:
@@ -126,6 +129,7 @@ help:
 	@echo "    PSM                Page segmentation mode. Default: $(PSM)"
 	@echo "    RANDOM_SEED        Random seed for shuffling of the training data. Default: $(RANDOM_SEED)"
 	@echo "    RATIO_TRAIN        Ratio of train / eval training data. Default: $(RATIO_TRAIN)"
+	@echo "    TARGET_ERROR_RATE  Stop training if mean percent error rate reached. Default: $(TARGET_ERROR_RATE)"
 
 # END-EVAL
 
@@ -254,7 +258,8 @@ $(LAST_CHECKPOINT): unicharset lists $(PROTO_MODEL)
 	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME) \
 	  --train_listfile $(OUTPUT_DIR)/list.train \
 	  --eval_listfile $(OUTPUT_DIR)/list.eval \
-	  --max_iterations $(MAX_ITERATIONS)
+	  --max_iterations $(MAX_ITERATIONS) \
+	  --target_error_rate $(TARGET_ERROR_RATE)
 $(OUTPUT_DIR).traineddata: $(LAST_CHECKPOINT)
 	lstmtraining \
 	--stop_training \
@@ -272,7 +277,8 @@ $(LAST_CHECKPOINT): unicharset lists $(PROTO_MODEL)
 	  --learning_rate 20e-4 \
 	  --train_listfile $(OUTPUT_DIR)/list.train \
 	  --eval_listfile $(OUTPUT_DIR)/list.eval \
-	  --max_iterations $(MAX_ITERATIONS)
+	  --max_iterations $(MAX_ITERATIONS) \
+	  --target_error_rate $(TARGET_ERROR_RATE)
 $(OUTPUT_DIR).traineddata: $(LAST_CHECKPOINT)
 	lstmtraining \
 	--stop_training \


### PR DESCRIPTION
Please enable the `lstm`parameter `target_error_rate` for tesstrain!

To control training flow it's not always best to got for the MAX_ITERATIONS. 
We need also a quality criteria for the model, so it fits a certain mean error rate above the default of value of 0.01 before MAX_ITERATIONS are applied.
