### PR TITLE
generate*.py: raise ValueError if GT is multiline, fix #162

### DIFF
--- a/generate_gt_from_box.py
+++ b/generate_gt_from_box.py
@@ -2,18 +2,20 @@
 
 import argparse
 import io
-import unicodedata
 
 #
 # command line arguments
 #
-arg_parser = argparse.ArgumentParser('''Creates groundtruth files from text2image generated box files''')
+arg_parser = argparse.ArgumentParser(
+    '''Creates groundtruth files from text2image generated box files''')
 
 # Text ground truth
-arg_parser.add_argument('-t', '--txt', nargs='?', metavar='TXT', help='Line text (GT)', required=True)
+arg_parser.add_argument('-t', '--txt', nargs='?',
+                        metavar='TXT', help='Line text (GT)', required=True)
 
 # Text box file
-arg_parser.add_argument('-b', '--box', nargs='?', metavar='BOX', help='text2image generated box file (BOX)', required=True)
+arg_parser.add_argument('-b', '--box', nargs='?', metavar='BOX',
+                        help='text2image generated box file (BOX)', required=True)
 
 args = arg_parser.parse_args()
 
@@ -25,6 +27,6 @@ args = arg_parser.parse_args()
 gtstring = io.StringIO()
 gtfile = open(args.txt, "w", encoding='utf-8')
 with io.open(args.box, "r", encoding='utf-8') as boxfile:
-        print(''.join(line.replace("  ","λ ").split(' ',1)[0] for line in boxfile if line), file = gtstring)
-gt = gtstring.getvalue().replace("λ"," ").replace("\t","\n")
-print(gt, file = gtfile)
+    print(''.join(line.replace("  ", "λ ").split(' ', 1)[0] for line in boxfile if line), file=gtstring)
+gt = gtstring.getvalue().replace("λ", " ").replace("\t", "\n")
+print(gt, file=gtfile)

--- a/generate_line_box.py
+++ b/generate_line_box.py
@@ -28,17 +28,18 @@ width, height = Image.open(args.image).size
 # load gt
 with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
+    if len(lines) > 1:
+        raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
+    line = unicodedata.normalize('NFC', lines[0].strip())
 
-for line in lines:
-    line = unicodedata.normalize('NFC', line.strip())
-    if line:
-        for i in range(1, len(line)):
-            char = line[i]
-            prev_char = line[i-1]
-            if unicodedata.combining(char):
-                print("%s 0 0 %d %d 0" % ((prev_char + char), width, height))
-            elif not unicodedata.combining(prev_char):
-                print("%s 0 0 %d %d 0" % (prev_char, width, height))
-        if not unicodedata.combining(line[-1]):
-            print("%s 0 0 %d %d 0" % (line[-1], width, height))
-        print("\t 0 0 %d %d 0" % (width, height))
+if line:
+    for i in range(1, len(line)):
+        char = line[i]
+        prev_char = line[i-1]
+        if unicodedata.combining(char):
+            print("%s 0 0 %d %d 0" % ((prev_char + char), width, height))
+        elif not unicodedata.combining(prev_char):
+            print("%s 0 0 %d %d 0" % (prev_char, width, height))
+    if not unicodedata.combining(line[-1]):
+        print("%s 0 0 %d %d 0" % (line[-1], width, height))
+    print("\t 0 0 %d %d 0" % (width, height))

--- a/generate_line_box.py
+++ b/generate_line_box.py
@@ -28,7 +28,7 @@ width, height = Image.open(args.image).size
 # load gt
 with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
-    if len(lines) > 1:
+    if len(lines) == 1:
         raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
     line = unicodedata.normalize('NFC', lines[0].strip())
 

--- a/generate_line_syllable_box.py
+++ b/generate_line_syllable_box.py
@@ -58,7 +58,7 @@ width, height = Image.open(args.image).size
 # load gt
 with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
-    if len(lines) > 1:
+    if len(lines) == 1:
         raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
     line = unicodedata.normalize('NFC', lines[0].strip())
 

--- a/generate_line_syllable_box.py
+++ b/generate_line_syllable_box.py
@@ -58,10 +58,11 @@ width, height = Image.open(args.image).size
 # load gt
 with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
+    if len(lines) > 1:
+        raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
+    line = unicodedata.normalize('NFC', lines[0].strip())
 
-for line in lines:
-    line = unicodedata.normalize('NFC', line.strip())
-    if line:
-        for syllable in (splitclusters(line)):
-            print("%s 0 0 %d %d 0" % (syllable, width, height))
-            print("\t 0 0 %d %d 0" % (width, height))
+if line:
+    for syllable in (splitclusters(line)):
+        print("%s 0 0 %d %d 0" % (syllable, width, height))
+        print("\t 0 0 %d %d 0" % (width, height))

--- a/generate_wordstr_box.py
+++ b/generate_wordstr_box.py
@@ -30,10 +30,11 @@ with open(args.image, "rb") as f:
 # load gt
 with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
+    if len(lines) > 1:
+        raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
+    line = unicodedata.normalize('NFC', lines[0].strip())
 
 # create WordStr line boxes for Indic & RTL
-for line in lines:
-    line = unicodedata.normalize('NFC', line.strip())
-    if line:
-        print("WordStr 0 0 %d %d 0 #%s" % (width, height, line))
-        print("\t 0 0 %d %d 0" % (width, height))
+if line:
+    print("WordStr 0 0 %d %d 0 #%s" % (width, height, line))
+    print("\t 0 0 %d %d 0" % (width, height))

--- a/generate_wordstr_box.py
+++ b/generate_wordstr_box.py
@@ -34,11 +34,10 @@ with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
     if len(lines) > 1:
         raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
-
+    line = unicodedata.normalize('NFC', lines[0].strip())
 
 # create WordStr line boxes for Indic & RTL
 if line:
-    line = unicodedata.normalize('NFC', lines[0].strip())
     line = bidi.algorithm.get_display(line)
     print("WordStr 0 0 %d %d 0 #%s" % (width, height, line))
     print("\t 0 0 %d %d 0" % (width, height))

--- a/generate_wordstr_box.py
+++ b/generate_wordstr_box.py
@@ -32,7 +32,7 @@ with open(args.image, "rb") as f:
 # load gt
 with io.open(args.txt, "r", encoding='utf-8') as f:
     lines = f.read().strip().split('\n')
-    if len(lines) > 1:
+    if len(lines) == 1:
         raise ValueError("ERROR: %s: Ground truth text file should contain exactly one line, not %s" % (args.txt, len(lines)))
     line = unicodedata.normalize('NFC', lines[0].strip())
 


### PR DESCRIPTION
`*.gt.txt` should contain a single line of transcribed text.