### PR TITLE
Add new variable LEARNING_RATE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,13 @@ MAX_ITERATIONS := 10000
 # Debug Interval. Default:  $(DEBUG_INTERVAL)
 DEBUG_INTERVAL := 0
 
+# Learning rate. Default: $(LEARNING_RATE)
+ifdef START_MODEL
+LEARNING_RATE := 0.0001
+else
+LEARNING_RATE := 0.002
+endif
+
 # Network specification. Default: $(NET_SPEC)
 NET_SPEC := [1,36,0,1 Ct3,3,16 Mp3,3 Lfys48 Lfx96 Lrx96 Lfx256 O1c\#\#\#]
 
@@ -127,6 +134,7 @@ help:
 	@echo "    GROUND_TRUTH_DIR   Ground truth directory. Default: $(GROUND_TRUTH_DIR)"
 	@echo "    MAX_ITERATIONS     Max iterations. Default: $(MAX_ITERATIONS)"
 	@echo "    DEBUG_INTERVAL     Debug Interval. Default:  $(DEBUG_INTERVAL)"
+	@echo "    LEARNING_RATE      Learning rate. Default: $(LEARNING_RATE)"
 	@echo "    NET_SPEC           Network specification. Default: $(NET_SPEC)"
 	@echo "    LANG_TYPE          Language Type - Indic, RTL or blank. Default: '$(LANG_TYPE)'"
 	@echo "    PSM                Page segmentation mode. Default: $(PSM)"
@@ -258,6 +266,7 @@ $(LAST_CHECKPOINT): unicharset lists $(PROTO_MODEL)
 	  --traineddata $(PROTO_MODEL) \
 	  --old_traineddata $(TESSDATA)/$(START_MODEL).traineddata \
 	  --continue_from data/$(START_MODEL)/$(MODEL_NAME).lstm \
+	  --learning_rate $(LEARNING_RATE) \
 	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME) \
 	  --train_listfile $(OUTPUT_DIR)/list.train \
 	  --eval_listfile $(OUTPUT_DIR)/list.eval \
@@ -275,9 +284,9 @@ $(LAST_CHECKPOINT): unicharset lists $(PROTO_MODEL)
 	lstmtraining \
 	  --debug_interval $(DEBUG_INTERVAL) \
 	  --traineddata $(PROTO_MODEL) \
+	  --learning_rate $(LEARNING_RATE) \
 	  --net_spec "$(subst c###,c`head -n1 $(OUTPUT_DIR)/unicharset`,$(NET_SPEC))" \
 	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME) \
-	  --learning_rate 20e-4 \
 	  --train_listfile $(OUTPUT_DIR)/list.train \
 	  --eval_listfile $(OUTPUT_DIR)/list.eval \
 	  --max_iterations $(MAX_ITERATIONS) \

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Run `make help` to see all the possible targets and variables:
     GROUND_TRUTH_DIR   Ground truth directory. Default: data/MODEL_NAME-ground-truth
     OUTPUT_DIR         Output directory for generated files. Default: data/MODEL_NAME
     MAX_ITERATIONS     Max iterations. Default: 10000
+    LEARNING_RATE      Learning rate. Default: 0.0001 with START_MODEL, otherwise 0.002
     NET_SPEC           Network specification. Default: [1,36,0,1 Ct3,3,16 Mp3,3 Lfys48 Lfx96 Lrx96 Lfx256 O1c\#\#\#]
     FINETUNE_TYPE      Finetune Training Type - Impact, Plus, Layer or blank. Default: ''
     LANG_TYPE          Language Type - Indic, RTL or blank. Default: ''


### PR DESCRIPTION
It allows setting the learning rate hyperparameter for the training.

The default value for finetuning is now reduced from 0.001 to 0.0001
because the old default was too large when finetuning starts with
a network which is already rather good.

Signed-off-by: Stefan Weil <sw@weilnetz.de>