### PR TITLE
Add makefile based training text and font to model scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ wackenroder_herzensergiessungen_*.tif
 master.zip
 plot/*.LOG
 plot/ocrd*
+data/
+src/training/__pycache__/
+src/training/tesstrain_utils-save.py
+src/training/tesstrain_utils-singlelines.py

--- a/Makefile-font2model
+++ b/Makefile-font2model
@@ -1,0 +1,227 @@
+export
+
+# Disable built-in suffix rules.
+# This makes starting with a very large number of GT lines much faster.
+.SUFFIXES:
+
+## Make sure that sort always uses the same sort order.
+LC_ALL := C
+
+SHELL := /bin/bash
+LOCAL := $(PWD)/usr
+PATH := $(LOCAL)/bin:$(PATH)
+
+# Path to the .traineddata directory with traineddata suitable for training 
+# (for example from tesseract-ocr/tessdata_best). Default: $(LOCAL)/share/tessdata
+TESSDATA =  $(LOCAL)/share/tessdata
+
+# Name of the model to be built. Default: $(MODEL_NAME)
+MODEL_NAME = foo
+
+# Data directory for output files, proto model, start model, etc. Default: $(DATA_DIR)
+DATA_DIR = data
+
+# Output directory for generated files. Default: $(OUTPUT_DIR)
+OUTPUT_DIR = $(DATA_DIR)/$(MODEL_NAME)
+
+# Name of the model to continue from. Default: '$(START_MODEL)'
+START_MODEL =
+
+LAST_CHECKPOINT = $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)_checkpoint
+
+# Name of the proto model. Default: '$(PROTO_MODEL)'
+PROTO_MODEL = $(OUTPUT_DIR)/$(MODEL_NAME).traineddata
+
+# Ground truth directory. Default: $(GROUND_TRUTH_DIR)
+GROUND_TRUTH_DIR := $(OUTPUT_DIR)-train
+
+# Max iterations. Default: $(MAX_ITERATIONS)
+MAX_ITERATIONS := 10000
+
+# Debug Interval. Default:  $(DEBUG_INTERVAL)
+DEBUG_INTERVAL := 0
+
+# Setup for Finetune, Replace top layer of network, from Scratch training
+ifeq ($(TRAIN_TYPE),FineTune)
+	NET_SPEC =--continue_from $(DATA_DIR)/$(START_MODEL)/$(MODEL_NAME).lstm --old_traineddata $(TESSDATA)/$(START_MODEL).traineddata
+	LEARNING_RATE := 0.0001
+else
+ifeq ($(TRAIN_TYPE),ReplaceLayer)
+	NET_SPEC =--continue_from $(DATA_DIR)/$(START_MODEL)/$(MODEL_NAME).lstm --append_index 5 --net_spec '[Lfx192O1c1]'
+	LEARNING_RATE := 0.001
+else
+	NET_SPEC =--net_spec [1,36,0,1 Ct3,3,16 Mp3,3 Lfys48 Lfx96 Lrx96 Lfx192O1c1]
+	LEARNING_RATE := 0.002
+endif
+endif
+
+# Default Target Error Rate. Default: $(TARGET_ERROR_RATE)
+TARGET_ERROR_RATE := 0.01
+
+# Default Fonts Directory. Default: $(TESSTRAIN_FONTS_DIR)
+TESSTRAIN_FONTS_DIR := /usr/share/fonts/
+
+# Default Training Text. Default: $(TESSTRAIN_TEXT)
+TESSTRAIN_TEXT := $(DATA_DIR)/$(MODEL_NAME)-train.training_text
+
+# Default Evaluation Text. Default: $(TESSEVAL_TEXT)
+TESSEVAL_TEXT := $(DATA_DIR)/$(MODEL_NAME)-eval.training_text
+
+# Font for training. Default: $(TESSTRAIN_FONT)
+TESSTRAIN_FONT =
+# Font List for training. Default: $(TESSTRAIN_FONT_LIST)
+ifdef TESSTRAIN_FONT
+TESSTRAIN_FONT_LIST =--fontlist $(TESSTRAIN_FONT)
+else
+TESSTRAIN_FONT_LIST =
+endif
+
+# Default maximum number of pages from training text. Default: $(TESSTRAIN_MAX_PAGES)
+TESSTRAIN_MAX_PAGES := 0
+
+# Default Script for training. Default: $(TESSTRAIN_SCRIPT)
+TESSTRAIN_SCRIPT := Latin
+
+# Default Language for training. Default: $(TESSTRAIN_LANG)
+TESSTRAIN_LANG := eng
+
+# BEGIN-EVAL makefile-parser --make-help Makefile
+
+help:
+	@echo ""
+	@echo "  Targets"
+	@echo ""
+	@echo "    lists                  Create lists of lstmf filenames for training and eval"
+	@echo "    training               Start training"
+	@echo "    traineddata            Create best and fast .traineddata files from each .checkpoint file"
+	@echo "    proto-model            Build the proto model"
+	@echo "    clean-log              Clean log file"
+	@echo "    clean-groundtruth      Clean generated groundtruth files"
+	@echo "    clean-output           Clean generated output files"
+	@echo "    clean                  Clean all generated files"
+	@echo ""
+	@echo "  Variables"
+	@echo ""
+	@echo "    TESSDATA              Path to the .traineddata directory with traineddata suitable for training "
+	@echo "                          (for example from tesseract-ocr/tessdata_best). Default: $(LOCAL)/share/tessdata"
+	@echo "    MODEL_NAME            Name of the model to be built. Default: $(MODEL_NAME)"
+	@echo "    OUTPUT_DIR            Output directory for generated files. Default: $(OUTPUT_DIR)"
+	@echo "    START_MODEL           Name of the model to continue from. Default: '$(START_MODEL)'"
+	@echo "    PROTO_MODEL           Name of the proto model. Default: '$(PROTO_MODEL)'"
+	@echo "    GROUND_TRUTH_DIR      Ground truth directory. Default: $(GROUND_TRUTH_DIR)"
+	@echo "    MAX_ITERATIONS        Max iterations. Default: $(MAX_ITERATIONS)"
+	@echo "    DEBUG_INTERVAL        Debug Interval. Default:  $(DEBUG_INTERVAL)"
+	@echo "    LEARNING_RATE         Learning rate. Default: $(LEARNING_RATE)"
+	@echo "    TARGET_ERROR_RATE     Target Error Rate. Default: $(TARGET_ERROR_RATE)"
+	@echo "    TESSTRAIN_FONTS_DIR   Fonts Directory. Default: $(TESSTRAIN_FONTS_DIR)"
+	@echo "    TESSTRAIN_TEXT        Training Text. Default: $(TESSTRAIN_TEXT)"
+	@echo "    TESSEVAL_TEXT         Evaluation Text. Default: $(TESSEVAL_TEXT)"
+	@echo "    TESSTRAIN_FONT        Font for training. Default: $(TESSTRAIN_FONT)"
+	@echo "    TESSTRAIN_MAX_PAGES   Maximum number of pages from training text. Default: $(TESSTRAIN_MAX_PAGES)"
+	@echo "    TESSTRAIN_LANG        Language code of existing language for creating PROTO_MODEL. "
+	@echo "                          (It can be the same as START_MODEL for fine-tuning). Default: $(TESSTRAIN_LANG)"
+	@echo "    TESSTRAIN_SCRIPT      Language Script (eg. Latin for eng, Bengali for ben). Default: $(TESSTRAIN_SCRIPT)"
+	@echo "    TRAIN_TYPE            Training Type - FineTune, ReplaceLayer or blank (from scratch). Default: '$(TRAIN_TYPE)'"
+	
+# END-EVAL
+
+.PRECIOUS: $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)*_checkpoint
+
+.PHONY: clean help proto_model lists training traineddata
+
+# Create lists of lstmf filenames for training and eval
+lists: $(OUTPUT_DIR)/list.train $(OUTPUT_DIR)/list.eval
+
+# Start training
+training: $(OUTPUT_DIR).traineddata
+
+$(OUTPUT_DIR).traineddata: $(LAST_CHECKPOINT)
+	lstmtraining \
+	--stop_training \
+	--continue_from $(LAST_CHECKPOINT) \
+	--traineddata $(PROTO_MODEL) \
+	--model_output $@
+
+$(LAST_CHECKPOINT): proto_model lists
+ifdef START_MODEL
+	  @mkdir -p $(DATA_DIR)/$(START_MODEL)
+	  combine_tessdata -e $(TESSDATA)/$(START_MODEL).traineddata  $(DATA_DIR)/$(START_MODEL)/$(MODEL_NAME).lstm
+endif
+	@mkdir -p $(OUTPUT_DIR)/checkpoints 
+	lstmtraining \
+	  $(NET_SPEC) \
+	  --traineddata $(PROTO_MODEL) \
+	  --train_listfile $(OUTPUT_DIR)/list.train \
+	  --eval_listfile $(OUTPUT_DIR)/list.eval \
+	  --max_iterations $(MAX_ITERATIONS) \
+	  --debug_interval $(DEBUG_INTERVAL) \
+	  --learning_rate $(LEARNING_RATE) \
+	  --target_error_rate $(TARGET_ERROR_RATE) \
+	  --model_output $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME) \
+	  > $(DATA_DIR)/$(MODEL_NAME).log 2>&1
+
+proto_model: $(PROTO_MODEL) 
+
+$(OUTPUT_DIR)/list.train $(PROTO_MODEL): $(OUTPUT_DIR)/list.eval
+	python ./src/training/tesstrain.py \
+	 --fonts_dir $(TESSTRAIN_FONTS_DIR) \
+	 $(TESSTRAIN_FONT_LIST) \
+	 --maxpages $(TESSTRAIN_MAX_PAGES) \
+	 --lang $(TESSTRAIN_LANG) \
+	 --langdata_dir $(DATA_DIR) \
+	 --training_text $(TESSTRAIN_TEXT) \
+	 --tessdata_dir $(TESSDATA) \
+	 --linedata_only --noextract_font_properties \
+	 --exposures "0" \
+	 --output_dir $(DATA_DIR)/$(MODEL_NAME)-train
+	mkdir -p $(DATA_DIR)/$(MODEL_NAME)
+	mv -v $(DATA_DIR)/$(MODEL_NAME)-train/$(TESSTRAIN_LANG).training_files.txt $(DATA_DIR)/$(MODEL_NAME)/list.train
+	mv -v $(DATA_DIR)/$(MODEL_NAME)-train/$(TESSTRAIN_LANG)/$(TESSTRAIN_LANG).* $(DATA_DIR)/$(MODEL_NAME)/
+	rename "s/$(TESSTRAIN_LANG)\./$(MODEL_NAME)\./g" $(DATA_DIR)/$(MODEL_NAME)/*.*
+	rm -v $(DATA_DIR)/$(MODEL_NAME)-train/tesstrain.log
+	rm -rf -v $(DATA_DIR)/$(MODEL_NAME)-train/$(TESSTRAIN_LANG)
+
+$(OUTPUT_DIR)/list.eval: $(DATA_DIR)/$(TESSTRAIN_SCRIPT).unicharset
+	python ./src/training/tesstrain.py \
+	 --fonts_dir $(TESSTRAIN_FONTS_DIR) \
+	 $(TESSTRAIN_FONT_LIST) \
+	 --maxpages 1 \
+	 --lang $(TESSTRAIN_LANG) \
+	 --langdata_dir $(DATA_DIR) \
+	 --training_text $(TESSEVAL_TEXT) \
+	 --tessdata_dir $(TESSDATA) \
+	 --linedata_only --noextract_font_properties \
+	 --exposures "0" \
+	 --save_box_tiff \
+	 --output_dir $(DATA_DIR)/$(MODEL_NAME)-eval
+	mkdir -p $(DATA_DIR)/$(MODEL_NAME)
+	mv -v $(DATA_DIR)/$(MODEL_NAME)-eval/$(TESSTRAIN_LANG).training_files.txt $(DATA_DIR)/$(MODEL_NAME)/list.eval
+	mv -v $(DATA_DIR)/$(MODEL_NAME)-eval/$(TESSTRAIN_LANG)/$(TESSTRAIN_LANG).* $(DATA_DIR)/$(MODEL_NAME)/
+	rename "s/$(TESSTRAIN_LANG)\./$(MODEL_NAME)-eval\./g" $(DATA_DIR)/$(MODEL_NAME)/*.*
+	rm -v $(DATA_DIR)/$(MODEL_NAME)-eval/tesstrain.log
+	rm -rf -v $(DATA_DIR)/$(MODEL_NAME)-eval/$(TESSTRAIN_LANG)
+	bash -x box2gt.sh $(MODEL_NAME)-eval
+	
+$(DATA_DIR)/$(TESSTRAIN_SCRIPT).unicharset: $(DATA_DIR)/Latin.unicharset $(DATA_DIR)/radical-stroke.txt
+	wget -O $@ 'https://github.com/tesseract-ocr/langdata_lstm/raw/master/$(TESSTRAIN_SCRIPT).unicharset'
+	
+$(DATA_DIR)/Latin.unicharset:
+	wget -O $@ 'https://github.com/tesseract-ocr/langdata_lstm/raw/master/Latin.unicharset'
+
+$(DATA_DIR)/radical-stroke.txt:
+	wget -O$@ 'https://github.com/tesseract-ocr/langdata_lstm/raw/master/radical-stroke.txt'
+
+# Clean generated output files
+
+clean-log:
+	rm -rf $(DATA_DIR)/$(MODEL_NAME).log
+	
+clean-groundtruth:
+	rm -rf $(GROUND_TRUTH_DIR)
+	
+.PHONY: clean-output
+clean-output:
+	rm -rf $(OUTPUT_DIR)
+
+# Clean all generated files
+clean: clean-output

--- a/box2gt.sh
+++ b/box2gt.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+rm -v $(find data/${1}/ -size 0 -name "*.box"|sed s/.box/.*/)
+  my_files=$(find data/${1}/ -name "*.box")
+    for my_file in ${my_files}; do
+      python generate_gt_from_box.py -b ${my_file} -t ${my_file%.*}.gt.txt
+	  sleep 1
+ 	  echo ${my_file}
+	  touch ${my_file%.*}.tif
+	  touch ${my_file%.*}.box
+	  touch ${my_file%.*}.lstmf
+    done
+cd data/${1}/
+    #for f in *.*; do pre="${f%.*}"; suf="${f##*.}";     mkdir -p "${pre//\.exp0.*/}"; mv -i -- "$f" "${pre//\.exp0\./\/}.${suf}"; done
+	rm -v -rf tesstrain
+	rm -v -rf eng
+	rm -v tesstrain.log
+cd ../..

--- a/font2model.sh
+++ b/font2model.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# $1 - TESSTRAIN_LANG
+# $2 - TESSTRAIN_SCRIPT
+# $3 - START_MODEL
+# $4 - MODEL_NAME
+# $5 - TRAIN_TYPE - FineTune, ReplaceLayer or blank (from scratch)
+# $6 - TESSTRAIN_FONT
+# $7 - TESSTRAIN_MAX_PAGES per font
+##
+
+# nohup bash -x font2model.sh eng Latin eng iast ReplaceLayer ' "Arial Unicode MS" "Times New Roman," ' 25 > iast.log &
+
+rm -rf /tmp 
+fc-cache -vf
+
+shuf -o data/$4-train.training_text < data/$4.training_text
+shuf -o data/$4-eval.training_text < data/EVAL.training_text
+
+make -f Makefile-font2model \
+MODEL_NAME=$4 \
+clean-groundtruth \
+clean-output \
+clean-log
+
+make -f Makefile-font2model \
+TESSDATA=$HOME/tessdata_best \
+TESSTRAIN_FONTS_DIR=/usr/share/fonts \
+TESSTRAIN_TEXT=data/$4-train.training_text \
+TESSEVAL_TEXT=data/$4-eval.training_text \
+TESSTRAIN_MAX_PAGES=$7 \
+MAX_ITERATIONS=1000000 \
+TESSTRAIN_LANG=$1 \
+TESSTRAIN_SCRIPT=$2 \
+START_MODEL=$3 \
+MODEL_NAME=$4 \
+TRAIN_TYPE=$5 \
+TESSTRAIN_FONT="$6" \
+DEBUG_INTERVAL=-1 \
+training  --trace


### PR DESCRIPTION
Builds a model using synthetic training data generated from 
- training text
- evaluation text
- fonts

A helper bash script is provided to ensure that all required values are passed to makefile.

The box/tiff pairs are saved for the evaluation data and gt.txt is generated from the box files.