### PR TITLE
Add --vertical_fontlist option to tesstrain.py

### DIFF
--- a/src/training/tesstrain_utils.py
+++ b/src/training/tesstrain_utils.py
@@ -141,6 +141,13 @@ parser.add_argument(
     type=str,
     help="A list of fontnames to train on.",
 )
+parser.add_argument(
+    "--vertical_fontlist",
+    dest="vertical_fonts",
+    nargs="+",
+    type=str,
+    help="A list of fontnames to render vertical text.",
+)
 parser.add_argument("--fonts_dir", help="Path to font files.")
 parser.add_argument("--tmp_dir", help="Path to temporary training directory.")
 parser.add_argument(
@@ -337,7 +344,8 @@ def generate_font_image(ctx, font, exposure, char_spacing):
 
     # add --writing_mode=vertical-upright to common_args if the font is
     # specified to be rendered vertically.
-    if font in VERTICAL_FONTS:
+    vertical_fonts = ctx.vertical_fonts or VERTICAL_FONTS
+    if font in vertical_fonts:
         common_args.append("--writing_mode=vertical-upright")
 
     run_command(


### PR DESCRIPTION
Porting from https://github.com/tesseract-ocr/tesseract/pull/3434 (not merged) .
>This Pull Request adds --vertical_fontlist option to tesstrain.sh to specify a list of fontnames to render vertical text.
>The format for specifying a list of fontnames is the same as for --font_list option.
>If --vertical_fontlist <FONTS> option is specified, it will override the VERTICLA_FONTS variable(defined in language-specific.sh) with the specified list of fontnames.

>In the current version, the VERTICAL_FONTS variable is hardcoded in language-specific.sh. So, when creating training data for vertical text such as Japanese, users need to edit the source code even if they specify a list of fontnames with --fontlist and --font_dir.

