### PR TITLE
prevent checkpoint file from being deleted when "make training" is interrupted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ help:
 
 # END-EVAL
 
-.PRECIOUS: $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)*_checkpoint
+.PRECIOUS: $(LAST_CHECKPOINT)
 
 .PHONY: clean help leptonica lists proto-model tesseract tesseract-langs tesseract-langdata training unicharset charfreq
 


### PR DESCRIPTION
Make would delete the xxx_checkpoint file when being interrupted, to prevent that, a .PRECIOUS rule was added, but the old one didn't prevent deletion if the xxx_checkpoint file didn't exist at the time of the make invocation, because wildcards are resolved at the start.

The other checkpoint files would never get removed by make anyway, since they are not listed as targets.

Therefore, replace the wildcard rule with $(LAST_CHECKPOINT).