### PR TITLE
Make last checkpoint also precious

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ help:
 # END-EVAL
 
 .PRECIOUS: $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)*_checkpoint
+.PRECIOUS: $(LAST_CHECKPOINT)
 
 .PHONY: clean help leptonica lists proto-model tesseract tesseract-langs tesseract-langdata training unicharset charfreq
 


### PR DESCRIPTION
The last checkpoint is useful for resuming a training session that has been interrupted for whatever reason, so don't delete it.