### PR TITLE
Remove build rules for Tesseract and Leptonica

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ data/unicharset
 dta19-reduced
 dta19-reduced.tar.gz
 *.built
-tesseract-*
-leptonica-*
 *.BAK
 /usr
 data/checkpoints

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tesstrain
 
-> Training workflow for Tesseract 4 as a Makefile for dependency tracking and building the required software from source.
+> Training workflow for Tesseract 5 as a Makefile for dependency tracking.
 
 ## Install
 
@@ -10,27 +10,15 @@ You will need at least GNU `make` (minimal version 4.2), `wget`, `find`, `bash`,
 
 ### Leptonica, Tesseract
 
-You will need a recent version (>= 4.0.0beta1) of tesseract built with the
+You will need a recent version (>= 5.3) of tesseract built with the
 training tools and matching leptonica bindings.
-[Build](https://github.com/tesseract-ocr/tesseract/wiki/Compiling)
-[instructions](https://github.com/tesseract-ocr/tesseract/wiki/Compiling-%E2%80%93-GitInstallation)
-and more can be found in the [Tesseract project
-wiki](https://github.com/tesseract-ocr/tesseract/wiki/).
-
-Alternatively, you can build leptonica and tesseract within this project and install it to a subdirectory `./usr` in the repo:
-
-```sh
-  make leptonica tesseract
-```
-
-Tesseract will be built from the git repository, which requires CMake,
-autotools (including autotools-archive) and some additional libraries for the
-training tools. See the [installation notes in the tesseract
-repository](https://github.com/tesseract-ocr/tesseract/blob/main/INSTALL.GIT.md).
+[Build](https://tesseract-ocr.github.io/tessdoc/Compiling)
+[instructions](https://tesseract-ocr.github.io/tessdoc/Compiling-%E2%80%93-GitInstallation)
+and more can be found in the [Tesseract User Manual](https://tesseract-ocr.github.io/tessdoc/).
 
 #### Windows
 
-  1. Install the latest tesseract (e.g. from https://digi.bib.uni-mannheim.de/tesseract/) make sure that tesseract is add to your PATH.
+  1. Install the latest tesseract (e.g. from https://digi.bib.uni-mannheim.de/tesseract/), make sure that tesseract is added to your PATH.
   2. Install [Python 3](https://www.python.org/downloads/)
   3. Install [Git SCM to Windows](https://gitforwindows.org/) - it provides a lot of linux utilities on Windows (e.g. `find`, `unzip`, `rm`) and put `C:\Program Files\Git\usr\bin` to the begining of your PATH variable (temporarely you can do it in `cmd` with `set PATH=C:\Program Files\Git\usr\bin;%PATH%` - unfornatelly there are several Windows tools with the same name as on linux (`find`, `sort`) with different behaviour/functionality and there is need to avoid them during training.
   4. Install winget/[Windows Package Manager](https://github.com/microsoft/winget-cli/releases/) and then run `winget install GnuWin32.Make` and `winget install wget` to install missing tools.
@@ -110,9 +98,6 @@ Run `make help` to see all the possible targets and variables:
     training         Start training
     traineddata      Create best and fast .traineddata files from each .checkpoint file
     proto-model      Build the proto model
-    leptonica        Build leptonica
-    tesseract        Build tesseract
-    tesseract-langs  Download minimal stock models
     tesseract-langdata  Download stock unicharsets
     clean            Clean all generated files
 
@@ -127,9 +112,6 @@ Run `make help` to see all the possible targets and variables:
     DATA_DIR           Data directory for output files, proto model, start model, etc. Default: data
     OUTPUT_DIR         Output directory for generated files. Default: DATA_DIR/MODEL_NAME
     GROUND_TRUTH_DIR   Ground truth directory. Default: OUTPUT_DIR-ground-truth
-    CORES              No of cores to use for compiling leptonica/tesseract. Default: 4
-    LEPTONICA_VERSION  Leptonica version. Default: 1.78.0
-    TESSERACT_VERSION  Tesseract commit. Default: 4.1.1
     TESSDATA_REPO      Tesseract model repo to use (_fast or _best). Default: _best
     TESSDATA           Path to the .traineddata directory to start finetuning from. Default: ./usr/share/tessdata
     MAX_ITERATIONS     Max iterations. Default: 10000


### PR DESCRIPTION
Recent releases of Tesseract and Leptonica are available for all major platforms (Linux, MacOS, Windows), so local build rules are more confusing than helpful.

Update also the links to the online documentation.