### PR TITLE
Prepare train data before running training

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,14 +386,14 @@ $(BEST_LSTMEVAL_FILES): $(OUTPUT_DIR)/eval/%.eval.log: $(OUTPUT_DIR)/tessdata_be
 TSV_LSTMEVAL = $(OUTPUT_DIR)/lstmeval.tsv
 .INTERMEDIATE: $(TSV_LSTMEVAL)
 $(TSV_LSTMEVAL): $(BEST_LSTMEVAL_FILES)
-	@echo "Name CheckpointCER	LearningIteration	TrainingIteration	EvalCER IterationCER	SubtrainerCER" > "$@"
+	@echo "Name	CheckpointCER	LearningIteration	TrainingIteration	EvalCER	IterationCER	SubtrainerCER" > "$@"
 	@{ $(foreach F,$^,echo -n "$F "; grep BCER $F;) } | sort -rn | \
-	sed -e 's|^$(OUTPUT_DIR)/eval/$(MODEL_NAME)_\([0-9.]*\)_\([0-9]*\)_\([0-9]*\).eval.log BCER eval=\([0-9.]*\).*$$|\t\1\t\2\t\3\t\4\t\t|' >>	"$@"
+	sed -e 's|^$(OUTPUT_DIR)/eval/$(MODEL_NAME)_\([0-9.]*\)_\([0-9]*\)_\([0-9]*\).eval.log BCER eval=\([0-9.]*\).*$$|\t\1\t\2\t\3\t\4\t\t|' >>  "$@"
 # Make TSV with CER at every 100 iterations.
 TSV_100_ITERATIONS = $(OUTPUT_DIR)/iteration.tsv
 .INTERMEDIATE: $(TSV_100_ITERATIONS)
 $(TSV_100_ITERATIONS): $(LOG_FILE)
-	@echo "Name CheckpointCER	LearningIteration	TrainingIteration	EvalCER IterationCER	SubtrainerCER" > "$@"
+	@echo "Name	CheckpointCER	LearningIteration	TrainingIteration	EvalCER	IterationCER	SubtrainerCER" > "$@"
 	@grep 'At iteration' $< \
 		| sed -e '/^Sub/d' \
 		| sed -e '/^Update/d' \
@@ -404,29 +404,29 @@ $(TSV_100_ITERATIONS): $(LOG_FILE)
 TSV_CHECKPOINT = $(OUTPUT_DIR)/checkpoint.tsv
 .INTERMEDIATE: $(TSV_CHECKPOINT)
 $(TSV_CHECKPOINT): $(LOG_FILE)
-	@echo "Name CheckpointCER	LearningIteration	TrainingIteration	EvalCER IterationCER	SubtrainerCER" > "$@"
+	@echo "Name	CheckpointCER	LearningIteration	TrainingIteration	EvalCER	IterationCER	SubtrainerCER" > "$@"
 	@grep 'best model' $< \
 		| sed -e 's/^.*\///' \
 		| sed -e 's/\.checkpoint.*$$/\t\t\t/' \
-		| sed -e 's/_/\t/g' >>	"$@"
+		| sed -e 's/_/\t/g' >>  "$@"
 # Make TSV with Eval CER.
 TSV_EVAL = $(OUTPUT_DIR)/eval.tsv
 .INTERMEDIATE: $(TSV_EVAL)
 $(TSV_EVAL): $(LOG_FILE)
-	@echo "Name CheckpointCER	LearningIteration	TrainingIteration	EvalCER IterationCER	SubtrainerCER" > "$@"
+	@echo "Name	CheckpointCER	LearningIteration	TrainingIteration	EvalCER	IterationCER	SubtrainerCER" > "$@"
 	@grep 'BCER eval' $< \
 		| sed -e 's/^.*[0-9]At iteration //' \
 		| sed -e 's/,.* BCER eval=/\t\t/'  \
 		| sed -e 's/, BWER.*$$/\t\t/' \
-		| sed -e 's/^/\t\t/' >>	 "$@"
+		| sed -e 's/^/\t\t/' >>  "$@"
 # Make TSV with Subtrainer CER.
 TSV_SUB = $(OUTPUT_DIR)/sub.tsv
 .INTERMEDIATE: $(TSV_SUB)
 $(TSV_SUB): $(LOG_FILE)
-	@echo "Name CheckpointCER	LearningIteration	TrainingIteration	EvalCER IterationCER	SubtrainerCER" > "$@"
+	@echo "Name	CheckpointCER	LearningIteration	TrainingIteration	EvalCER	IterationCER	SubtrainerCER" > "$@"
 	@grep '^UpdateSubtrainer' $< \
 		| sed -e 's/^.*At iteration \([0-9]*\)\/\([0-9]*\)\/.*BCER train=/\t\t\1\t\2\t\t\t/' \
-		| sed -e 's/%, BWER.*//' >>	 "$@"
+		| sed -e 's/%, BWER.*//' >>  "$@"
 
 $(OUTPUT_DIR)/$(MODEL_NAME).plot_log.png: $(TSV_100_ITERATIONS) $(TSV_CHECKPOINT) $(TSV_EVAL) $(TSV_SUB)
 	$(PY_CMD) plot_log.py $@ $(MODEL_NAME) $^

--- a/Makefile
+++ b/Makefile
@@ -208,17 +208,17 @@ $(ALL_GT): $(ALL_FILES) | $(OUTPUT_DIR)
 	$(if $^,,$(error found no $(GROUND_TRUTH_DIR)/*.gt.txt for $@))
 	$(file >$@) $(foreach F,$^,$(file >>$@,$(file <$F)))
 
-# Generate ALL_LSTMF recursively
+# Generate ALL_LSTMF recursively and then shuffle it
 $(ALL_LSTMF): $(ALL_FILES:%.gt.txt=%.lstmf) | $(OUTPUT_DIR)
 	$(if $^,,$(error found no $(GROUND_TRUTH_DIR)/*.lstmf for $@))
 	@mkdir -p $(@D)
 	$(file >$@) $(foreach F,$^,$(file >>$@,$F))
+	$(PY_CMD) shuffle.py $(RANDOM_SEED) "$@"
 
-# Modified list generation with recursive discovery
+# Modified list generation
 $(LIST_TRAIN) $(LIST_EVAL): $(ALL_LSTMF) | $(OUTPUT_DIR)
 	@if [ ! -f $(LIST_TRAIN) ] || [ ! -f $(LIST_EVAL) ]; then \
 		echo "Generating new train/eval lists"; \
-		find -L $(GROUND_TRUTH_DIR) -type f -name '*.lstmf' | sort > $(ALL_LSTMF); \
 		total_files=$$(wc -l < $(ALL_LSTMF)); \
 		train_count=$$(echo "$$total_files * $(RATIO_TRAIN)" | bc | cut -d. -f1); \
 		head -n $$train_count $(ALL_LSTMF) > $(LIST_TRAIN); \


### PR DESCRIPTION
Added an option to prepare the train and eval indices from the ground truth before starting the training with `make prepare-data`. 

This gives you more control over what’s used to evaluate the training, which is super handy if you have different sets of training data (like different fonts or special symbols). Now, we go through the folder and all the subfolders in the specified ground truth folder to gather all the different _sets_ of training data, combine them into one training set, and then fine-tune what gets used for evaluation."