### PR TITLE
Update Makefile %.lstmf targets with TESSDATA and START_MODEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,19 +245,19 @@ $(ALL_LSTMF): $(ALL_FILES:%.gt.txt=%.lstmf)
 
 .PRECIOUS: %.lstmf
 %.lstmf: %.png %.box
-	tesseract "$<" $* --psm $(PSM) lstm.train
+	tesseract "$<" $* --psm $(PSM) --tessdata-dir $(TESSDATA) -l $(START_MODEL) lstm.train
 
 %.lstmf: %.bin.png %.box
-	tesseract "$<" $* --psm $(PSM) lstm.train
+	tesseract "$<" $* --psm $(PSM) --tessdata-dir $(TESSDATA) -l $(START_MODEL) lstm.train
 
 %.lstmf: %.nrm.png %.box
-	tesseract "$<" $* --psm $(PSM) lstm.train
+	tesseract "$<" $* --psm $(PSM) --tessdata-dir $(TESSDATA) -l $(START_MODEL) lstm.train
 
 %.lstmf: %.raw.png %.box
-	tesseract "$<" $* --psm $(PSM) lstm.train
+	tesseract "$<" $* --psm $(PSM) --tessdata-dir $(TESSDATA) -l $(START_MODEL) lstm.train
 
 %.lstmf: %.tif %.box
-	tesseract "$<" $* --psm $(PSM) lstm.train
+	tesseract "$<" $* --psm $(PSM) --tessdata-dir $(TESSDATA) -l $(START_MODEL) lstm.train
 
 .PHONY: traineddata
 CHECKPOINT_FILES = $(wildcard $(OUTPUT_DIR)/checkpoints/$(MODEL_NAME)*.checkpoint)


### PR DESCRIPTION
When training a new model based on a model that I had already created, I needed to be able to specify where the previously trained model's traineddata file was located and what its language name was.  This patch in the Makefile enables that functionality.